### PR TITLE
fix: 在有 userId 情况下调用 clearUserId 会导致崩溃

### DIFF
--- a/Example/autotracker-upgrade-2to3-cdp/AppDelegate.m
+++ b/Example/autotracker-upgrade-2to3-cdp/AppDelegate.m
@@ -59,6 +59,8 @@
 //    config.dataCollectionServerHost = @"https://run.mocky.io/v3/08999138-a180-431d-a136-051f3c6bd306";
 #if Autotracker
     [GrowingAutotracker startWithConfiguration:config launchOptions:launchOptions];
+    [[GrowingAutotracker sharedInstance] cleanLoginUserId];
+    [[GrowingAutotracker sharedInstance] setLoginUserId:@"11111"];
 #else
     [GrowingTracker startWithConfiguration:config launchOptions:launchOptions];
 #endif

--- a/GrowingAnalytics-upgrade.podspec
+++ b/GrowingAnalytics-upgrade.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'GrowingAnalytics-upgrade'
-  s.version          = '1.1.3'
+  s.version          = '1.1.4'
   s.summary          = 'GrowingIO SDK udgrade, support for 2.x to 3.x'
   s.description      = <<-DESC
 TODO: Add long description of the pod here.

--- a/Upgrade-base/GrowingUpgradeDispatcher.m
+++ b/Upgrade-base/GrowingUpgradeDispatcher.m
@@ -91,8 +91,13 @@
 #pragma mark - GrowingUserIdChangedDelegate
 
 - (void)userIdDidChangedFrom:(NSString *)oldUserId to:(NSString *)newUserId {
-    GrowingEBUserIdEvent *setUserIdEvent = [[GrowingEBUserIdEvent alloc] initWithData:@{@"data": newUserId} operateType:GrowingSetUserIdType];
-    [GrowingEventBus send:setUserIdEvent];
+    if (newUserId == nil) {
+        GrowingEBUserIdEvent *setUserIdEvent = [[GrowingEBUserIdEvent alloc] initWithData:nil operateType:GrowingClearUserIdType];
+        [GrowingEventBus send:setUserIdEvent];
+    } else {
+        GrowingEBUserIdEvent *setUserIdEvent = [[GrowingEBUserIdEvent alloc] initWithData:@{@"data": newUserId} operateType:GrowingSetUserIdType];
+        [GrowingEventBus send:setUserIdEvent];
+    }
 }
 
 #pragma mark - GrowingViewControllerLifecycleDelegate


### PR DESCRIPTION
## PR 内容

- fix: 在有 userId 情况下调用 clearUserId 会导致崩溃


## 测试步骤

- 连续 2 次启动 Demo，测试是否正常（已在 Demo 启动时调用 clearUserId）

## 影响范围

- 1.1.3 及以前版本，在有 userId 情况下调用 clearUserId 会导致崩溃

## 是否属于重要变动？

- [ ] 是
- [x] 否

## 其他信息

```
2021-12-01 16:02:38.862322+0800 iOSDemo[47511:3302559] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[0]'
*** First throw call stack:
(
	0   CoreFoundation                      0x00007fff203fbbb4 __exceptionPreprocess + 242
	1   libobjc.A.dylib                     0x00007fff2019ebe7 objc_exception_throw + 48
	2   CoreFoundation                      0x00007fff2047bf38 _CFThrowFormattedException + 194
	3   CoreFoundation                      0x00007fff2048642e -[__NSPlaceholderDictionary initWithCapacity:].cold.1 + 0
	4   CoreFoundation                      0x00007fff20469914 -[__NSPlaceholderDictionary initWithObjects:forKeys:count:] + 251
	5   CoreFoundation                      0x00007fff203fa83b +[NSDictionary dictionaryWithObjects:forKeys:count:] + 49
	6   iOSDemo                             0x000000010d0dfb9b -[GrowingUpgradeDispatcher userIdDidChangedFrom:to:] + 155
	7   iOSDemo                             0x000000010d090f55 -[GrowingSession dispatchUserIdDidChangedFrom:to:] + 581
	8   iOSDemo                             0x000000010d0913c4 -[GrowingSession setLoginUserId:userKey:] + 836
	9   iOSDemo                             0x000000010d091855 -[GrowingSession setLoginUserId:] + 69
	10  iOSDemo                             0x000000010d08e114 __38-[GrowingRealTracker cleanLoginUserId]_block_invoke + 68
	11  iOSDemo                             0x000000010d04d3e1 +[GrowingDispatchManager dispatchBlock:] + 65
	12  Foundation                          0x00007fff2084258c __NSThreadPerformPerform + 207
	13  CoreFoundation                      0x00007fff20369e25 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 17
	14  CoreFoundation                      0x00007fff20369d1d __CFRunLoopDoSource0 + 180
	15  CoreFoundation                      0x00007fff203691f2 __CFRunLoopDoSources0 + 242
	16  CoreFoundation                      0x00007fff20363951 __CFRunLoopRun + 875
	17  CoreFoundation                      0x00007fff20363103 CFRunLoopRunSpecific + 567
	18  Foundation                          0x00007fff2081941c -[NSRunLoop(NSRunLoop) runMode:beforeDate:] + 213
	19  iOSDemo                             0x000000010d09e6db -[GrowingThread main] + 267
	20  Foundation                          0x00007fff20842142 __NSThread__start__ + 999
	21  libsystem_pthread.dylib             0x00007fff6bff5514 _pthread_start + 125
	22  libsystem_pthread.dylib             0x00007fff6bff102f thread_start + 15
)
```

